### PR TITLE
Fix for https://github.com/Flowgistics/laravel-xml/issues/3

### DIFF
--- a/src/Data/XMLElement.php
+++ b/src/Data/XMLElement.php
@@ -16,7 +16,7 @@ class XMLElement extends SimpleXMLElement
      */
     public function attribute(string $name, mixed $default = null): mixed
     {
-        return $this->attributes()->{$name} ?? $default;
+        return !is_null($this->attributes()->{$name}) ? (string)$this->attributes()->{$name} : $default;
     }
 
     /**

--- a/tests/Unit/XMLImportTest.php
+++ b/tests/Unit/XMLImportTest.php
@@ -30,6 +30,7 @@ class XMLImportTest extends TestCase
         $path = __DIR__.'/../Features/Import/stubs/notes.xml';
         $xml = XML::import($path)->get()->note;
 
+        $this->assertIsString($xml->attribute('completed'));
         $this->assertEquals('true', $xml->attribute('completed'));
         $this->assertEquals('0', $xml->attribute('stars', '2'));
         $this->assertEquals('1', $xml->attribute('shares', '2'));


### PR DESCRIPTION
This fixes #3.

The reason why the test were passing previously:

As ```$this->assertEquals('true', $xml->attribute('completed'));``` does no strict comparison, code with strict evaluations will fail. This requires either to use ```assertString``` additionally or ```assertSame``` vs ```assertEquals```. 

A implicit conversion was happening to string, but strict value comparisons in other code would break and fail with the changes in #2. As XML attributes are always strings, the returned values should be always strings, such the check ```assertString``` was added.

This commit fixes this issue while keeping #2 intact too. 
